### PR TITLE
Update "Lobby" model

### DIFF
--- a/src/events/events.gateway.spec.ts
+++ b/src/events/events.gateway.spec.ts
@@ -23,6 +23,7 @@ describe('EventsGateway', () => {
     LOBBYMAN.lobbies = {};
     LOBBYMAN.activeMachines = {};
     LOBBYMAN.machineConnections = {};
+    LOBBYMAN.spectatorConnections = {};
 
     socket = io('http://localhost:3001');
     socket.connect();

--- a/src/events/events.gateway.spec.ts
+++ b/src/events/events.gateway.spec.ts
@@ -21,7 +21,6 @@ describe('EventsGateway', () => {
   beforeEach(() => {
     // Clear out data before every test.
     LOBBYMAN.lobbies = {};
-    LOBBYMAN.activeMachines = {};
     LOBBYMAN.machineConnections = {};
     LOBBYMAN.spectatorConnections = {};
 
@@ -34,7 +33,7 @@ describe('EventsGateway', () => {
       const code = await new Promise<string>((resolve) => {
         socket.emit(
           'createLobby',
-          { machine: { machineId: '1', player1: { playerName: 'teejusb' } } },
+          { machine: { player1: { playerName: 'teejusb' } } },
           (data: string) => {
             expect(data.length).toEqual(4);
             resolve(data);
@@ -90,8 +89,7 @@ describe('EventsGateway', () => {
       });
 
       await new Promise((resolve) => {
-        socket.emit('leaveLobby', { machineId: '1' }, (didLeave: boolean) => {
-          console.log('in callback');
+        socket.emit('leaveLobby', {}, (didLeave: boolean) => {
           expect(didLeave).toEqual(true);
           resolve(undefined);
         });

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -64,7 +64,8 @@ function DisconnectMachine(socketId: SocketId): boolean {
           }
 
           machine.socket.leave(code);
-          // Don't disconnect here, as we have a callback.
+          // Don't disconnect here, as we may be re-using the connection.
+          // In the case of `leaveLobby`, the client can manually disconnect.
         }
         delete lobby.machines[socketId];
         delete LOBBYMAN.machineConnections[socketId];
@@ -73,6 +74,8 @@ function DisconnectMachine(socketId: SocketId): boolean {
           for (const spectator of Object.values(lobby.spectators)) {
             if (spectator.socket) {
               spectator.socket.leave(code);
+              // Force a disconnect. If there are no more players in the lobby,
+              // we should remove the spectators as well.
               spectator.socket.disconnect();
               delete LOBBYMAN.spectatorConnections[spectator.socket.id];
             }
@@ -86,7 +89,6 @@ function DisconnectMachine(socketId: SocketId): boolean {
   return false;
 }
 
-// Disconnect and remove a spectator from a lobby.
 function DisconnectSpectator(socketId: SocketId): boolean {
   const code = LOBBYMAN.spectatorConnections[socketId];
   if (code) {

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -1,0 +1,123 @@
+import { SocketId } from 'socket.io-adapter';
+import { LOBBYMAN, Lobby } from '../types/models.types';
+
+/**
+ * Determines if the correct credentials are provided to join a lobby.
+ * @param code, The lobby code to join.
+ * @param password, The password to join the lobby with.
+ * @returns True if the lobby exists and the password is correct, false
+ *          otherwise.
+ */
+export function CanJoinLobby(code: string, password: string) {
+  // Does the lobby we're trying to join exist?
+  if (code in LOBBYMAN.lobbies) {
+    const lobby = LOBBYMAN.lobbies[code];
+    // Join either if the lobby is public, or one has provided a valid
+    // password for a private lobby.
+    if (!lobby.password || lobby.password === password) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Generates a random lobby code.
+ * @returns A random lobby code of 4 uppercase characters.
+ */
+export function GenerateLobbyCode(): string {
+  const lobbyCodeLength = 4;
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  let result = '';
+  for (let i = 0; i < lobbyCodeLength; ++i) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+}
+
+/**
+ * Gets the number of players in a lobby.
+ * @param lobby, The lobby to get the player count for.
+ * @returns The number of players in the lobby.
+ */
+export function GetPlayerCountForLobby(lobby: Lobby): number {
+  let playerCount = 0;
+  for (const machine of Object.values(lobby.machines)) {
+    if (machine.player1 !== undefined) {
+      playerCount += 1;
+    }
+    if (machine.player2 !== undefined) {
+      playerCount += 1;
+    }
+  }
+  return playerCount;
+}
+
+/**
+ * Makes a machine leave a lobby. If the machine was the last player in the
+ * lobby, the lobby will be deleted and all spectators will be disconnected.
+ * @param socketId, The socket ID of the machine to disconnect.
+ * @returns True if the machine left the lobby, false otherwise.
+ */
+export function DisconnectMachine(socketId: SocketId): boolean {
+  const code = LOBBYMAN.machineConnections[socketId];
+  if (code) {
+    const lobby = LOBBYMAN.lobbies[code];
+    if (lobby) {
+      const machine = lobby.machines[socketId];
+      if (machine) {
+        if (machine.socket) {
+          if (machine.socket.id in LOBBYMAN.machineConnections) {
+            delete LOBBYMAN.machineConnections[machine.socket.id];
+          }
+
+          machine.socket.leave(code);
+          // Don't disconnect here, as we may be re-using the connection.
+          // In the case of `leaveLobby`, the client can manually disconnect.
+        }
+        delete lobby.machines[socketId];
+        delete LOBBYMAN.machineConnections[socketId];
+
+        if (GetPlayerCountForLobby(lobby) === 0) {
+          for (const spectator of Object.values(lobby.spectators)) {
+            if (spectator.socket) {
+              spectator.socket.leave(code);
+              // Force a disconnect. If there are no more players in the lobby,
+              // we should remove the spectators as well.
+              spectator.socket.disconnect();
+              delete LOBBYMAN.spectatorConnections[spectator.socket.id];
+            }
+          }
+          delete LOBBYMAN.lobbies[code];
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Makes a spectator leave a lobby.
+ * @param socketId, The socket ID of the spectator to disconnect.
+ * @returns, True if the spectator left the lobby, false otherwise.
+ */
+export function DisconnectSpectator(socketId: SocketId): boolean {
+  const code = LOBBYMAN.spectatorConnections[socketId];
+  if (code) {
+    const lobby = LOBBYMAN.lobbies[code];
+    if (lobby) {
+      const spectator = lobby.spectators[socketId];
+      if (spectator) {
+        if (spectator.socket) {
+          spectator.socket.leave(code);
+          // Don't disconnect here, as we may be re-using the connection.
+        }
+        delete lobby.spectators[socketId];
+        delete LOBBYMAN.spectatorConnections[socketId];
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,6 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   LOBBYMAN.lobbies = {};
-  LOBBYMAN.activeMachines = {};
   LOBBYMAN.machineConnections = {};
   LOBBYMAN.spectatorConnections = {};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ async function bootstrap() {
   LOBBYMAN.lobbies = {};
   LOBBYMAN.activeMachines = {};
   LOBBYMAN.machineConnections = {};
+  LOBBYMAN.spectatorConnections = {};
 
   await app.listen(3000);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   LOBBYMAN.lobbies = {};
-  LOBBYMAN.activePlayers = {};
+  LOBBYMAN.activeMachines = {};
+  LOBBYMAN.machineConnections = {};
 
   await app.listen(3000);
 }

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -49,7 +49,6 @@ export class Player {
   playerId: string;
   profileName: string;
 
-  // Provided by each player.
   judgments?: Judgments;
   score?: number;
   exScore?: number;

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -1,3 +1,4 @@
+import { Socket } from 'socket.io';
 import { SocketId } from 'socket.io-adapter';
 
 export class Judgments {
@@ -17,18 +18,9 @@ export class Judgments {
   totalRolls: number;
 }
 
-export class Player {
-  playerId: string;
-  profileName: string;
-
-  // Provided by each player.
-  judgments?: Judgments;
-  score?: number;
-  exScore?: number;
-}
-
 export class Spectator {
-  profileName?: string;
+  profileName: string;
+  socket?: Socket;
 }
 
 export class SongInfo {
@@ -44,7 +36,7 @@ export class SongInfo {
   // sufficient in that case. Additionally, StepMania doesn't currently have a
   // way to jump to a specific song based only on it's chart (as there may be
   // conflicts). As a result, players that split up/rename the pack will not be
-  // able easily play with players that don't as the songPaths will be
+  // able easily play with players that don't, as the songPaths will be
   // different.
   songPath: string;
   title: string;
@@ -53,29 +45,48 @@ export class SongInfo {
   songLength: number;
 }
 
+export class Player {
+  playerId: string;
+  profileName: string;
+
+  // Provided by each player.
+  judgments?: Judgments;
+  score?: number;
+  exScore?: number;
+}
+
+export class Machine {
+  machineId: string;
+  player1?: Player;
+  player2?: Player;
+  socket?: Socket;
+}
+
 export class Lobby {
   code: string;
-  // Empty string here is equivalent to "no password".
+  // Empty string here is equivalent to "no password". We could use undefined
+  // but we can consider them the same.
   password: string;
-  players: Record<string, Player>;
+  machines: Record<string, Machine>;
   spectators: Spectator[];
 
   songInfo?: SongInfo;
-
-  // All connected socketIds. This will include all the socketIds for both
-  // players and spectators. Note that more than one player may be connected for
-  // each client.
-  connectedSocketIds: Set<SocketId>;
 }
 
 export class LobbyInfo {
   code: string;
   isPasswordProtected: boolean;
   playerCount: number;
+  spectatorCount: number;
 }
 
 export class LOBBYMAN {
+  // Mapping from lobby code to a Lobby
   static lobbies: Record<string, Lobby>;
-  // Mapping from playerId to the lobby code they're in.
-  static activePlayers: Record<string, string>;
+
+  // Mapping from machine to the lobby code of the lobby it's connected to.
+  static activeMachines: Record<string, string>;
+
+  // Mapping from socketId to the machineId.
+  static machineConnections: Record<SocketId, string>;
 }

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -1,3 +1,5 @@
+import { SocketId } from 'socket.io-adapter';
+
 export class Judgments {
   fantasticPlus: number;
   fantastics: number;
@@ -19,9 +21,8 @@ export class Player {
   playerId: string;
   profileName: string;
 
+  // Provided by each player.
   judgments?: Judgments;
-
-  // Scores are recalculated as the the judgments come in.
   score?: number;
   exScore?: number;
 }
@@ -30,16 +31,46 @@ export class Spectator {
   profileName?: string;
 }
 
+export class SongInfo {
+  // The path for the song on a player's filesystem.
+  // We'll use this as a key for other players to play.
+  // e.g. 5guys1pack/Earthquake
+  //
+  // NOTE(teejusb): This requires all connected players to have those packs on
+  // their machine.
+  //
+  // NOTE(teejusb): We want to allow players to play the same *song* even if
+  // they may be different difficulties. Using a chartHash or similar is not
+  // sufficient in that case. Additionally, StepMania doesn't currently have a
+  // way to jump to a specific song based only on it's chart (as there may be
+  // conflicts). As a result, players that split up/rename the pack will not be
+  // able easily play with players that don't as the songPaths will be
+  // different.
+  songPath: string;
+  title: string;
+  artist: string;
+  stepartist: string;
+  songLength: number;
+}
+
 export class Lobby {
   code: string;
   // Empty string here is equivalent to "no password".
   password: string;
   players: Record<string, Player>;
   spectators: Spectator[];
+
+  songInfo?: SongInfo;
+
+  // All connected socketIds. This will include all the socketIds for both
+  // players and spectators. Note that more than one player may be connected for
+  // each client.
+  connectedSocketIds: Set<SocketId>;
 }
 
 export class LobbyInfo {
   code: string;
+  isPasswordProtected: boolean;
   playerCount: number;
 }
 

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -56,7 +56,6 @@ export class Player {
 }
 
 export class Machine {
-  machineId: string;
   player1?: Player;
   player2?: Player;
   socket?: Socket;
@@ -67,7 +66,7 @@ export class Lobby {
   // Empty string here is equivalent to "no password". We could use undefined
   // but we can consider them the same.
   password: string;
-  machines: Record<string, Machine>;
+  machines: Record<SocketId, Machine>;
   spectators: Record<SocketId, Spectator>;
 
   songInfo?: SongInfo;
@@ -84,10 +83,7 @@ export class LOBBYMAN {
   // Mapping from lobby code to a Lobby
   static lobbies: Record<string, Lobby>;
 
-  // Mapping from machine id to the lobby code of the lobby it's connected to.
-  static activeMachines: Record<string, string>;
-
-  // Mapping from socketId to the machineId.
+  // Mapping from socketId to the lobby code of the lobby it's connected to.
   static machineConnections: Record<SocketId, string>;
 
   // Mapping from socketId to the lobby code for the spectators.

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -68,7 +68,7 @@ export class Lobby {
   // but we can consider them the same.
   password: string;
   machines: Record<string, Machine>;
-  spectators: Spectator[];
+  spectators: Record<SocketId, Spectator>;
 
   songInfo?: SongInfo;
 }
@@ -84,9 +84,12 @@ export class LOBBYMAN {
   // Mapping from lobby code to a Lobby
   static lobbies: Record<string, Lobby>;
 
-  // Mapping from machine to the lobby code of the lobby it's connected to.
+  // Mapping from machine id to the lobby code of the lobby it's connected to.
   static activeMachines: Record<string, string>;
 
   // Mapping from socketId to the machineId.
   static machineConnections: Record<SocketId, string>;
+
+  // Mapping from socketId to the lobby code for the spectators.
+  static spectatorConnections: Record<SocketId, string>;
 }


### PR DESCRIPTION
- Introduced a concept of `Machines`, which the players are now a part of (`Machines` join a `Lobby` instead of `Players` now).
- Update tests to use `await` to ensure that we wait for the server before moving to the next `emit` call.
- Use the `SocketId` as the identifier for `Machines` and `Spectators`. Keep track of them in the `machineConnections` and `spectatorConnections` maps respectively for easy access.