### PR TITLE
Feature/ws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,11 @@
         "@nestjs/common": "^10.3.7",
         "@nestjs/core": "^10.3.7",
         "@nestjs/platform-express": "^10.3.7",
-        "@nestjs/platform-socket.io": "^10.3.7",
         "@nestjs/platform-ws": "^10.3.7",
         "@nestjs/websockets": "^10.3.7",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
-        "socket.io-client": "^4.6.1",
         "uuid": "^11.0.2",
         "ws": "^8.18.0"
       },
@@ -1607,6 +1605,8 @@
       "version": "10.3.7",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.3.7.tgz",
       "integrity": "sha512-T9VbVgEUnbid/RiywN9/8YQ8pAGDP++0nX73l4kIWeDWkz5DEh4aLB7O/JvLA3/xRHdjTZ4RiRZazwqSWi1Sog==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "socket.io": "4.7.5",
         "tslib": "2.6.2"
@@ -1802,7 +1802,9 @@
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -1891,7 +1893,9 @@
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
@@ -1903,6 +1907,8 @@
       "version": "2.8.17",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
       "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2020,7 +2026,8 @@
     "node_modules/@types/node": {
       "version": "16.18.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
-      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
+      "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2926,6 +2933,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -3527,6 +3536,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3743,6 +3753,8 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
       "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -3759,51 +3771,12 @@
         "node": ">=10.2.0"
       }
     },
-    "node_modules/engine.io-client": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.11.0",
-        "xmlhttprequest-ssl": "~2.0.0"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/engine.io/node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3812,6 +3785,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
       "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3821,6 +3796,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
       "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6831,7 +6808,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "devOptional": true
     },
     "node_modules/multer": {
       "version": "1.4.4-lts.1",
@@ -8175,6 +8153,8 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
       "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
@@ -8192,6 +8172,8 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
       "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "debug": "~4.3.4",
         "ws": "~8.11.0"
@@ -8202,6 +8184,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
       "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8218,24 +8202,12 @@
         }
       }
     },
-    "node_modules/socket.io-client": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
-      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.4.0",
-        "socket.io-parser": "~4.2.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
       "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -9403,14 +9375,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xmlhttprequest-ssl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {
@@ -10660,6 +10624,8 @@
       "version": "10.3.7",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.3.7.tgz",
       "integrity": "sha512-T9VbVgEUnbid/RiywN9/8YQ8pAGDP++0nX73l4kIWeDWkz5DEh4aLB7O/JvLA3/xRHdjTZ4RiRZazwqSWi1Sog==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "socket.io": "4.7.5",
         "tslib": "2.6.2"
@@ -10776,7 +10742,9 @@
     "@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "optional": true,
+      "peer": true
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -10865,7 +10833,9 @@
     "@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "optional": true,
+      "peer": true
     },
     "@types/cookiejar": {
       "version": "2.1.2",
@@ -10877,6 +10847,8 @@
       "version": "2.8.17",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
       "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -10994,7 +10966,8 @@
     "@types/node": {
       "version": "16.18.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.23.tgz",
-      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
+      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g==",
+      "devOptional": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11659,7 +11632,9 @@
     "base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "optional": true,
+      "peer": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -12092,6 +12067,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "devOptional": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -12250,6 +12226,8 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
       "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
@@ -12266,45 +12244,26 @@
         "cookie": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+          "optional": true,
+          "peer": true
         },
         "engine.io-parser": {
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
-          "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw=="
+          "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
+          "optional": true,
+          "peer": true
         },
         "ws": {
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
           "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "optional": true,
+          "peer": true,
           "requires": {}
         }
       }
-    },
-    "engine.io-client": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
-      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
-      "requires": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.3",
-        "ws": "~8.11.0",
-        "xmlhttprequest-ssl": "~2.0.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-          "requires": {}
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
-      "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw=="
     },
     "enhanced-resolve": {
       "version": "5.12.0",
@@ -14540,7 +14499,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "devOptional": true
     },
     "multer": {
       "version": "1.4.4-lts.1",
@@ -15527,6 +15487,8 @@
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
       "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
@@ -15541,6 +15503,8 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
       "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "debug": "~4.3.4",
         "ws": "~8.11.0"
@@ -15550,25 +15514,18 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
           "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "optional": true,
+          "peer": true,
           "requires": {}
         }
-      }
-    },
-    "socket.io-client": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
-      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
-      "requires": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.4.0",
-        "socket.io-parser": "~4.2.1"
       }
     },
     "socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
       "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -16397,11 +16354,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "requires": {}
-    },
-    "xmlhttprequest-ssl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
-        "socket.io-client": "^4.6.1"
+        "socket.io-client": "^4.6.1",
+        "uuid": "^11.0.2",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -28,6 +30,7 @@
         "@types/jest": "28.1.8",
         "@types/node": "^16.0.0",
         "@types/supertest": "^2.0.11",
+        "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.1",
@@ -2090,6 +2093,16 @@
         "@types/superagent": "*"
       }
     },
+    "node_modules/@types/ws": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -3758,6 +3771,27 @@
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
@@ -3780,6 +3814,27 @@
       "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -8142,6 +8197,27 @@
         "ws": "~8.11.0"
       }
     },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
@@ -9019,6 +9095,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9296,15 +9385,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -10977,6 +11067,15 @@
         "@types/superagent": "*"
       }
     },
+    "@types/ws": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -12173,6 +12272,12 @@
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
           "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw=="
+        },
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "requires": {}
         }
       }
     },
@@ -12186,6 +12291,14 @@
         "engine.io-parser": "~5.0.3",
         "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "requires": {}
+        }
       }
     },
     "engine.io-parser": {
@@ -15431,6 +15544,14 @@
       "requires": {
         "debug": "~4.3.4",
         "ws": "~8.11.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "requires": {}
+        }
       }
     },
     "socket.io-client": {
@@ -16057,6 +16178,11 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
+    "uuid": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
+      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ=="
+    },
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -16267,9 +16393,9 @@
       }
     },
     "ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "requires": {}
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
-    "socket.io-client": "^4.6.1"
+    "socket.io-client": "^4.6.1",
+    "uuid": "^11.0.2",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
@@ -46,6 +48,7 @@
     "@types/jest": "28.1.8",
     "@types/node": "^16.0.0",
     "@types/supertest": "^2.0.11",
+    "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,11 @@
     "@nestjs/common": "^10.3.7",
     "@nestjs/core": "^10.3.7",
     "@nestjs/platform-express": "^10.3.7",
-    "@nestjs/platform-socket.io": "^10.3.7",
     "@nestjs/platform-ws": "^10.3.7",
     "@nestjs/websockets": "^10.3.7",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
-    "socket.io-client": "^4.6.1",
     "uuid": "^11.0.2",
     "ws": "^8.18.0"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { EventsModule } from './events/events.module';
+import { ClientModule } from './clients/client.module';
 
 @Module({
-  imports: [EventsModule],
+  imports: [EventsModule, ClientModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/clients/client.module.ts
+++ b/src/clients/client.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ClientService } from './client.service';
+
+@Module({
+  providers: [ClientService],
+  exports: [ClientService],
+})
+export class ClientModule {}

--- a/src/clients/client.service.ts
+++ b/src/clients/client.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import WebSocket = require('ws');
+import { Message } from '../events/events.types';
+import { SocketId, LobbyCode, ROOMMAN } from '../types/models.types';
+import { v4 as uuid } from 'uuid';
+@Injectable()
+export class ClientService {
+  // Mapping from socketId to the lobby code for the spectators.
+  private clients: Map<SocketId, WebSocket> = new Map();
+
+  getSocketId(targetSocket: WebSocket): SocketId {
+    for (const [socketId, socket] of this.clients.entries()) {
+      if (socket === targetSocket) return socketId;
+    }
+    throw new Error('Socket not found');
+  }
+
+  /** Sends a message to all connected clients */
+  sendAll(response: Message) {
+    this.clients.forEach((socket) => {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify(response));
+      }
+    });
+  }
+
+  /** Sends a message to a specific socket */
+  sendSocket(response: Message, socketId: SocketId) {
+    const socket = this.clients.get(socketId);
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      console.warn('Cannot send to socket, socket is not connected');
+      return;
+    }
+    socket.send(JSON.stringify(response));
+  }
+
+  /** Sends a message to all clients in a particular lobby */
+  sendLobby(response: Message, code: LobbyCode) {
+    this.clients.forEach((socket, socketId) => {
+      // skip clients not in the lobby
+      if (!ROOMMAN.isJoined(socketId, code)) return;
+
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify(response));
+      }
+    });
+  }
+
+  disconnect(socketId: SocketId, reason?: string) {
+    if (!this.clients.has(socketId)) {
+      console.warn(`Client ${socketId} not connected`);
+      return;
+    }
+
+    const message: Message = {
+      type: 'clientDisconnected',
+      payload: { reason: reason || 'Just because' },
+    };
+
+    const client = this.clients.get(socketId);
+    if (!client) return;
+
+    if (client.readyState === WebSocket.OPEN) {
+      this.clients.get(socketId)?.close(1000, JSON.stringify(message));
+    }
+    this.clients.delete(socketId);
+  }
+
+  connect(socket: WebSocket): string {
+    // Assert we're not already connected
+    const entry = Object.entries(this.clients).find(
+      ([, value]) => socket === value,
+    );
+    if (entry) {
+      console.warn(`Socket ${entry[0]} is already connected`);
+      return entry[0];
+    }
+
+    // Generate an id for the entry, set and return it
+    const socketId = uuid();
+    this.clients.set(socketId, socket);
+    console.log('Socket connected: ', socketId);
+    return socketId;
+  }
+}

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -64,20 +64,24 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const socketId = CLIENTS.connect(socket);
 
     socket.on('message', async (messageBuffer: Buffer) => {
-      const message: Message = JSON.parse(messageBuffer.toString());
-      if (!message.type || !message.payload) {
-        throw new Error('Message requires a type and a payload');
-      }
-      if (!this.handlers.has(message.type)) {
-        throw new Error(`No handler for message type "${message.type}"`);
-      }
-      const handler = this.handlers.get(message.type);
-      if (!handler) {
-        throw new Error('Missing handler'); // Should not happen, but makes TS happy
-      }
-      const response = await handler(socketId, message.payload);
-      if (response) {
-        CLIENTS.sendSocket(response, socketId);
+      try {
+        const message: Message = JSON.parse(messageBuffer.toString());
+        if (!message.type || !message.payload) {
+          throw new Error('Message requires a type and a payload');
+        }
+        if (!this.handlers.has(message.type)) {
+          throw new Error(`No handler for message type "${message.type}"`);
+        }
+        const handler = this.handlers.get(message.type);
+        if (!handler) {
+          throw new Error('Missing handler'); // Should not happen, but makes TS happy
+        }
+        const response = await handler(socketId, message.payload);
+        if (response) {
+          CLIENTS.sendSocket(response, socketId);
+        }
+      } catch (e) {
+        console.error('Error handling message', e);
       }
     });
   }

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -37,20 +37,24 @@ import { ClientService } from '../clients/client.service';
 export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   /** Maps received message types to a callback function to handle those message.
    * The callback function may return a message to send to the calling socket */
-  private handlers: Map<
-    MessageType,
-    (socketId: SocketId, payload: any) => Promise<Message | undefined>
-  > = new Map();
+  private handlers: Partial<
+    Record<
+      MessageType,
+      (socketId: SocketId, payload: any) => Promise<Message | undefined>
+    >
+  >;
 
   constructor(private readonly clients: ClientService) {}
 
   afterInit() {
-    this.handlers.set('createLobby', this.createLobby);
-    this.handlers.set('joinLobby', this.joinLobby);
-    this.handlers.set('leaveLobby', this.leaveLobby);
-    this.handlers.set('spectateLobby', this.spectateLobby);
-    this.handlers.set('searchLobby', this.searchLobby);
-    this.handlers.set('readyUp', this.readyUp);
+    this.handlers = {
+      createLobby: this.createLobby,
+      joinLobby: this.joinLobby,
+      leaveLobby: this.leaveLobby,
+      spectateLobby: this.spectateLobby,
+      searchLobby: this.searchLobby,
+      readyUp: this.readyUp,
+    };
   }
 
   /**
@@ -65,10 +69,10 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
         if (!message.type || !message.payload) {
           throw new Error('Message requires a type and a payload');
         }
-        if (!this.handlers.has(message.type)) {
+        if (!this.handlers[message.type]) {
           throw new Error(`No handler for message type "${message.type}"`);
         }
-        const handler = this.handlers.get(message.type);
+        const handler = this.handlers[message.type];
         if (!handler) {
           throw new Error('Missing handler'); // Should not happen, but makes TS happy
         }

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -2,9 +2,7 @@ import {
   OnGatewayConnection,
   OnGatewayDisconnect,
   WebSocketGateway,
-  WebSocketServer,
 } from '@nestjs/websockets';
-import { Server } from 'socket.io';
 import { WebSocket } from 'ws';
 import {
   CLIENTS,
@@ -37,15 +35,14 @@ import {
   },
 })
 export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
-  @WebSocketServer()
-  server: Server;
-
+  /** Maps received message types to a callback function to handle those message.
+   * The callback function may return a message to send to the calling socket */
   private handlers: Map<
     MessageType,
-    (socketId: SocketId, payload: any) => Promise<Message>
+    (socketId: SocketId, payload: any) => Promise<Message | undefined>
   > = new Map();
 
-  afterInit(server: Server) {
+  afterInit() {
     this.handlers.set('createLobby', this.createLobby);
     this.handlers.set('joinLobby', this.joinLobby);
     this.handlers.set('leaveLobby', this.leaveLobby);

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -24,8 +24,14 @@ import {
   CreateLobbyPayload,
   JoinLobbyPayload,
   LobbyCreatedPayload,
+  LobbyJoinedPayload,
+  LobbyLeftPayload,
+  LobbySearchedPayload,
+  LobbySpectatedPayload,
   Message,
   MessageType,
+  ReadyUpResultPayload,
+  SearchLobbyPayload,
   SpectateLobbyPayload,
 } from './events.types';
 
@@ -112,7 +118,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   async createLobby(
     socketId: string,
     { machine, password }: CreateLobbyPayload,
-  ): Promise<Message> {
+  ): Promise<Message<LobbyCreatedPayload>> {
     if (socketId in LOBBYMAN.spectatorConnections) {
       disconnectSpectator(socketId);
     }
@@ -157,7 +163,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   async joinLobby(
     socketId: SocketId,
     { machine, code, password }: JoinLobbyPayload,
-  ): Promise<Message> {
+  ): Promise<Message<LobbyJoinedPayload>> {
     if (!canJoinLobby(code, password)) {
       return { type: 'lobbyJoined', payload: { joined: false } };
     }
@@ -188,7 +194,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
    * @param client, The socket connection of the machine to disconnect.
    * @returns, True if the machine was disconnected successfully.
    */
-  async leaveLobby(socketId: SocketId): Promise<Message> {
+  async leaveLobby(socketId: SocketId): Promise<Message<LobbyLeftPayload>> {
     const left = disconnectMachine(socketId);
     return { type: 'lobbyLeft', payload: { left } };
   }
@@ -204,7 +210,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   async spectateLobby(
     socketId: SocketId,
     { spectator, code, password }: SpectateLobbyPayload,
-  ): Promise<Message> {
+  ): Promise<Message<LobbySpectatedPayload>> {
     const lobby = LOBBYMAN.lobbies[code];
 
     if (!lobby) {
@@ -237,7 +243,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
    * Searches for all active lobbies.
    * @returns, The list of lobbies that are currently active.
    */
-  async searchLobby(): Promise<Message> {
+  async searchLobby(): Promise<Message<LobbySearchedPayload>> {
     const lobbies: LobbyInfo[] = Object.values(LOBBYMAN.lobbies).map((l) => ({
       code: l.code,
       isPasswordProtected: l.password.length !== 0,
@@ -252,7 +258,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
    * @param client, The socket that connected.
    * @returns, true if we successfully readied up, false otherwise.
    */
-  async readyUp(socketId: SocketId): Promise<Message> {
+  async readyUp(socketId: SocketId): Promise<Message<ReadyUpResultPayload>> {
     const response: Message = {
       type: 'readyUpResult',
       payload: { ready: false },

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
 import { EventsGateway } from './events.gateway';
+import { ClientService } from '../clients/client.service';
 
 @Module({
-  providers: [EventsGateway],
+  providers: [EventsGateway, ClientService],
 })
 export class EventsModule {}

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -42,9 +42,6 @@ export interface Message<T = MessagePayload> {
   payload: T;
 }
 
-// TODO: We can tighten types here, extend Message with the specific type/payload
-// Then our handler signatures can return the correct Message
-
 export interface CreateLobbyPayload {
   machine: Machine;
   password: string;
@@ -74,11 +71,8 @@ export interface LobbySpectatedPayload {
   spectators: number;
 }
 
-export interface SearchLobbyPayload {
-  spectator: Spectator;
-  code: LobbyCode;
-  password: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SearchLobbyPayload {}
 
 export interface LobbySearchedPayload {
   lobbies: LobbyInfo[];

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -37,9 +37,9 @@ export type MessagePayload =
   | LobbyStatePayload
   | StartSongPayload;
 
-export interface Message {
+export interface Message<T = MessagePayload> {
   type: MessageType;
-  payload: MessagePayload;
+  payload: T;
 }
 
 // TODO: We can tighten types here, extend Message with the specific type/payload

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -1,8 +1,11 @@
 import { Machine } from '../types/models.types';
 
-export type MessageType = 'createLobby' | 'lobbyCreated';
+export type MessageType = 'createLobby' | 'lobbyCreated' | 'clientDisconnected';
 
-export type MessagePayload = CreateLobbyPayload | LobbyCreatedPayload;
+export type MessagePayload =
+  | CreateLobbyPayload
+  | LobbyCreatedPayload
+  | ClientDisconnectedPayload;
 
 export interface Message {
   type: MessageType;
@@ -16,4 +19,8 @@ export interface CreateLobbyPayload {
 
 export interface LobbyCreatedPayload {
   code: Machine;
+}
+
+export interface ClientDisconnectedPayload {
+  reason: string;
 }

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -1,16 +1,49 @@
-import { Machine } from '../types/models.types';
+import {
+  LobbyCode,
+  LobbyInfo,
+  Machine,
+  Spectator,
+} from '../types/models.types';
 
-export type MessageType = 'createLobby' | 'lobbyCreated' | 'clientDisconnected';
+export type MessageType =
+  | 'createLobby'
+  | 'lobbyCreated'
+  | 'joinLobby'
+  | 'lobbyJoined'
+  | 'leaveLobby'
+  | 'lobbyLeft'
+  | 'spectateLobby'
+  | 'lobbySpectated'
+  | 'searchLobby'
+  | 'lobbySearched'
+  | 'clientDisconnected'
+  | 'readyUp'
+  | 'readyUpResult'
+  | 'lobbyState'
+  | 'startSong';
 
 export type MessagePayload =
   | CreateLobbyPayload
   | LobbyCreatedPayload
-  | ClientDisconnectedPayload;
+  | JoinLobbyPayload
+  | LobbyJoinedPayload
+  | LeaveLobbyPayload
+  | LobbyLeftPayload
+  | SearchLobbyPayload
+  | LobbySearchedPayload
+  | ClientDisconnectedPayload
+  | ReadyUpPayload
+  | ReadyUpResultPayload
+  | LobbyStatePayload
+  | StartSongPayload;
 
 export interface Message {
   type: MessageType;
   payload: MessagePayload;
 }
+
+// TODO: We can tighten types here, extend Message with the specific type/payload
+// Then our handler signatures can return the correct Message
 
 export interface CreateLobbyPayload {
   machine: Machine;
@@ -21,6 +54,58 @@ export interface LobbyCreatedPayload {
   code: Machine;
 }
 
+export interface JoinLobbyPayload {
+  machine: Machine;
+  code: LobbyCode;
+  password: string;
+}
+
+export interface LobbyJoinedPayload {
+  joined: boolean;
+}
+
+export interface SpectateLobbyPayload {
+  spectator: Spectator;
+  code: LobbyCode;
+  password: string;
+}
+
+export interface LobbySpectatedPayload {
+  spectators: number;
+}
+
+export interface SearchLobbyPayload {
+  spectator: Spectator;
+  code: LobbyCode;
+  password: string;
+}
+
+export interface LobbySearchedPayload {
+  lobbies: LobbyInfo[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface LeaveLobbyPayload {}
+
+export interface LobbyLeftPayload {
+  left: boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ReadyUpPayload {}
+
+export interface ReadyUpResultPayload {
+  ready: boolean;
+}
+
 export interface ClientDisconnectedPayload {
   reason: string;
+}
+
+export interface LobbyStatePayload {
+  machines: Machine[];
+}
+
+export interface StartSongPayload {
+  start: boolean;
 }

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -48,7 +48,7 @@ export interface CreateLobbyPayload {
 }
 
 export interface LobbyCreatedPayload {
-  code: Machine;
+  code: LobbyCode;
 }
 
 export interface JoinLobbyPayload {

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -1,0 +1,19 @@
+import { Machine } from '../types/models.types';
+
+export type MessageType = 'createLobby' | 'lobbyCreated';
+
+export type MessagePayload = CreateLobbyPayload | LobbyCreatedPayload;
+
+export interface Message {
+  type: MessageType;
+  payload: MessagePayload;
+}
+
+export interface CreateLobbyPayload {
+  machine: Machine;
+  password: string;
+}
+
+export interface LobbyCreatedPayload {
+  code: Machine;
+}

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -1,5 +1,11 @@
 import { SocketId } from 'socket.io-adapter';
-import { LOBBYMAN, Lobby, Machine } from '../types/models.types';
+import {
+  CLIENTS,
+  LOBBYMAN,
+  Lobby,
+  Machine,
+  ROOMMAN,
+} from '../types/models.types';
 
 /**
  * Determines if the correct credentials are provided to join a lobby.
@@ -82,8 +88,7 @@ export function disconnectMachine(socketId: SocketId): boolean {
       delete LOBBYMAN.machineConnections[machine.socketId];
     }
 
-    // TODO
-    // machine.socket.leave(code);
+    ROOMMAN.leave(machine.socketId, code);
     // Don't disconnect here, as we may be re-using the connection.
     // In the case of `leaveLobby`, the client can manually disconnect.
   }
@@ -93,12 +98,10 @@ export function disconnectMachine(socketId: SocketId): boolean {
   if (getPlayerCountForLobby(lobby) === 0) {
     for (const spectator of Object.values(lobby.spectators)) {
       if (spectator.socketId) {
-        // TODO
-        // spectator.socket.leave(code);
+        ROOMMAN.leave(spectator.socketId, code);
         // Force a disconnect. If there are no more players in the lobby,
         // we should remove the spectators as well.
-        // TODO
-        // spectator.socket.disconnect();
+        CLIENTS.disconnect(spectator.socketId);
         delete LOBBYMAN.spectatorConnections[spectator.socketId];
       }
     }
@@ -129,8 +132,7 @@ export function disconnectSpectator(socketId: SocketId): boolean {
   }
 
   if (spectator.socketId) {
-    // TODO
-    // spectator.socket.leave(code);
+    ROOMMAN.leave(spectator.socketId, code);
     // Don't disconnect here, as we may be re-using the connection.
   }
   delete lobby.spectators[socketId];

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -1,10 +1,9 @@
-import { SocketId } from 'socket.io-adapter';
 import {
   CLIENTS,
   LOBBYMAN,
   Lobby,
-  Machine,
   ROOMMAN,
+  SocketId,
 } from '../types/models.types';
 import { Message } from './events.types';
 

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -77,12 +77,13 @@ export function disconnectMachine(socketId: SocketId): boolean {
     return false;
   }
 
-  if (machine.socket) {
-    if (machine.socket.id in LOBBYMAN.machineConnections) {
-      delete LOBBYMAN.machineConnections[machine.socket.id];
+  if (machine.socketId) {
+    if (machine.socketId in LOBBYMAN.machineConnections) {
+      delete LOBBYMAN.machineConnections[machine.socketId];
     }
 
-    machine.socket.leave(code);
+    // TODO
+    // machine.socket.leave(code);
     // Don't disconnect here, as we may be re-using the connection.
     // In the case of `leaveLobby`, the client can manually disconnect.
   }
@@ -91,12 +92,14 @@ export function disconnectMachine(socketId: SocketId): boolean {
 
   if (getPlayerCountForLobby(lobby) === 0) {
     for (const spectator of Object.values(lobby.spectators)) {
-      if (spectator.socket) {
-        spectator.socket.leave(code);
+      if (spectator.socketId) {
+        // TODO
+        // spectator.socket.leave(code);
         // Force a disconnect. If there are no more players in the lobby,
         // we should remove the spectators as well.
-        spectator.socket.disconnect();
-        delete LOBBYMAN.spectatorConnections[spectator.socket.id];
+        // TODO
+        // spectator.socket.disconnect();
+        delete LOBBYMAN.spectatorConnections[spectator.socketId];
       }
     }
     delete LOBBYMAN.lobbies[code];
@@ -125,8 +128,9 @@ export function disconnectSpectator(socketId: SocketId): boolean {
     return false;
   }
 
-  if (spectator.socket) {
-    spectator.socket.leave(code);
+  if (spectator.socketId) {
+    // TODO
+    // spectator.socket.leave(code);
     // Don't disconnect here, as we may be re-using the connection.
   }
   delete lobby.spectators[socketId];
@@ -152,13 +156,10 @@ export function getLobbyState(socketId: SocketId): Machine[] | null {
     return null;
   }
 
-  const machineState: Machine[] = [];
-  for (const machine of Object.values(lobby.machines)) {
-    const machineCopy = { ...machine };
-    // Remove the socket from the machine state since we shouldn't be sending
-    // it back to the client.
-    machineCopy.socket = undefined;
-    machineState.push(machineCopy);
-  }
+  // Send back the machine state with the socket ids omitted
+  const machineState = Object.entries(lobby.machines).map((m) => ({
+    socketId,
+    ...m,
+  }));
   return machineState;
 }

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -1,10 +1,5 @@
-import {
-  CLIENTS,
-  LOBBYMAN,
-  Lobby,
-  ROOMMAN,
-  SocketId,
-} from '../types/models.types';
+import { ClientService } from '../clients/client.service';
+import { LOBBYMAN, Lobby, ROOMMAN, SocketId } from '../types/models.types';
 import { Message } from './events.types';
 
 /**
@@ -67,7 +62,10 @@ export function getPlayerCountForLobby(lobby: Lobby): number {
  * @param socketId, The socket ID of the machine to disconnect.
  * @returns True if the machine left the lobby, false otherwise.
  */
-export function disconnectMachine(socketId: SocketId): boolean {
+export function disconnectMachine(
+  socketId: SocketId,
+  clients: ClientService,
+): boolean {
   const code = LOBBYMAN.machineConnections[socketId];
   if (code === undefined) {
     return false;
@@ -101,7 +99,7 @@ export function disconnectMachine(socketId: SocketId): boolean {
         ROOMMAN.leave(spectator.socketId, code);
         // Force a disconnect. If there are no more players in the lobby,
         // we should remove the spectators as well.
-        CLIENTS.disconnect(spectator.socketId);
+        clients.disconnect(spectator.socketId);
         delete LOBBYMAN.spectatorConnections[spectator.socketId];
       }
     }

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -6,6 +6,7 @@ import {
   Machine,
   ROOMMAN,
 } from '../types/models.types';
+import { Message } from './events.types';
 
 /**
  * Determines if the correct credentials are provided to join a lobby.
@@ -152,16 +153,17 @@ export function getLobbyForMachine(socketId: SocketId): Lobby | undefined {
   return LOBBYMAN.lobbies[code];
 }
 
-export function getLobbyState(socketId: SocketId): Machine[] | null {
+export function getLobbyState(socketId: SocketId): Message | null {
   const lobby = getLobbyForMachine(socketId);
   if (lobby === undefined) {
     return null;
   }
 
   // Send back the machine state with the socket ids omitted
-  const machineState = Object.entries(lobby.machines).map((m) => ({
+  const machines = Object.entries(lobby.machines).map((m) => ({
     socketId,
     ...m,
   }));
-  return machineState;
+
+  return { type: 'lobbyState', payload: { machines } };
 }

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -93,16 +93,13 @@ export class LOBBYMAN {
 
 export class ROOMMAN {
   // Mapping of lobby ids (rooms) to the socketIds in that room
-  private static rooms: Map<LobbyCode, Array<SocketId>> = new Map();
+  private static rooms: Record<LobbyCode, Array<SocketId>> = {};
 
   static join(socketId: SocketId, code: LobbyCode) {
-    if (!this.rooms.has(code)) {
-      this.rooms.set(code, []);
+    if (!this.rooms[code]) {
+      this.rooms[code] = [];
     }
-    const sockets = this.rooms.get(code);
-    if (!sockets) {
-      throw new Error('No socket with code ' + code); // Shouldn't happen, since we set the code right before this
-    }
+    const sockets = this.rooms[code];
     if (sockets.includes(socketId)) {
       console.warn(`Socket ${socketId} is already in room ${code}`);
       return;
@@ -112,11 +109,11 @@ export class ROOMMAN {
   }
 
   static leave(socketId: SocketId, code: LobbyCode) {
-    if (!this.rooms.has(code)) {
+    if (!this.rooms[code]) {
       console.warn(`No room for code ${code}`);
       return;
     }
-    const sockets = this.rooms.get(code);
+    const sockets = this.rooms[code];
     if (!sockets) {
       throw new Error('No socket with code ' + code); // Shouldn't happen, since we set the code right before this
     }
@@ -125,14 +122,11 @@ export class ROOMMAN {
       return;
     }
     console.info(`Socket ${socketId} is leaving room ${code}`);
-    this.rooms.set(
-      code,
-      sockets.filter((s) => s !== socketId),
-    );
+    this.rooms[code] = sockets.filter((s) => s !== socketId);
   }
 
   static isJoined(socketId: SocketId, code: LobbyCode): boolean {
-    if (!this.rooms.has(code)) return false;
-    return Boolean(this.rooms.get(code)?.includes(socketId));
+    if (!this.rooms[code]) return false;
+    return Boolean(this.rooms[code].includes(socketId));
   }
 }

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -6,7 +6,7 @@ export type SocketId = string;
 
 export type LobbyCode = string;
 
-export class Judgments {
+export interface Judgments {
   fantasticPlus: number;
   fantastics: number;
   excellents: number;
@@ -23,12 +23,12 @@ export class Judgments {
   totalRolls: number;
 }
 
-export class Spectator {
+export interface Spectator {
   profileName: string;
   socketId?: SocketId;
 }
 
-export class SongInfo {
+export interface SongInfo {
   // The path for the song on a player's filesystem.
   // We'll use this as a key for other players to play.
   // e.g. 5guys1pack/Earthquake
@@ -50,7 +50,7 @@ export class SongInfo {
   songLength: number;
 }
 
-export class Player {
+export interface Player {
   playerId: string;
   profileName: string;
 
@@ -59,14 +59,14 @@ export class Player {
   exScore?: number;
 }
 
-export class Machine {
+export interface Machine {
   player1?: Player;
   player2?: Player;
   socketId?: SocketId;
   ready?: boolean;
 }
 
-export class Lobby {
+export interface Lobby {
   code: LobbyCode;
   // Empty string here is equivalent to "no password". We could use undefined
   // but we can consider them the same.
@@ -77,7 +77,7 @@ export class Lobby {
   songInfo?: SongInfo;
 }
 
-export class LobbyInfo {
+export interface LobbyInfo {
   code: LobbyCode;
   isPasswordProtected: boolean;
   playerCount: number;

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -130,15 +130,23 @@ export class ROOMMAN {
     );
     console.log(this.rooms);
   }
+
+  static isJoined(socketId: SocketId, code: LobbyCode): boolean {
+    if (!this.rooms.has(code)) return false;
+    return Boolean(this.rooms.get(code)?.includes(socketId));
+  }
 }
 
 export class CLIENTS {
   private static clients: Map<SocketId, WebSocket> = new Map();
 
-  static send(response: Message) {
-    this.clients.forEach((client) => {
-      if (client.readyState === WebSocket.OPEN) {
-        client.send(JSON.stringify(response));
+  static send(response: Message, code?: LobbyCode) {
+    this.clients.forEach((socket, socketId) => {
+      // if a lobby code is provided, ensure the client is actually in that lobby
+      if (code && !ROOMMAN.isJoined(socketId, code)) return;
+
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify(response));
       }
     });
   }

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -1,5 +1,4 @@
-import { Socket } from 'socket.io';
-import { SocketId } from 'socket.io-adapter';
+export type SocketId = string;
 
 export class Judgments {
   fantasticPlus: number;
@@ -20,7 +19,7 @@ export class Judgments {
 
 export class Spectator {
   profileName: string;
-  socket?: Socket;
+  socketId?: SocketId;
 }
 
 export class SongInfo {
@@ -57,7 +56,7 @@ export class Player {
 export class Machine {
   player1?: Player;
   player2?: Player;
-  socket?: Socket;
+  socketId?: SocketId;
   ready?: boolean;
 }
 

--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -110,7 +110,6 @@ export class ROOMMAN {
     }
     console.info(`Socket ${socketId} is joining room ${code}`);
     sockets.push(socketId);
-    console.log(this.rooms);
   }
 
   static leave(socketId: SocketId, code: LobbyCode) {
@@ -128,7 +127,6 @@ export class ROOMMAN {
       code,
       sockets.filter((s) => s !== socketId),
     );
-    console.log(this.rooms);
   }
 
   static isJoined(socketId: SocketId, code: LobbyCode): boolean {


### PR DESCRIPTION
This PR swaps out socket.io for websockets.

* Adds a new `ClientService` 
  * Maintains a mapping of connected client ids (`SocketId`) to the underlying sockets.
  * Handles sending messages to specific lobbies (aka rooms, another socket.io nicety) or sockets. 
* Changes the structure of sent/received messages.
  * Websocket `send` isn't as sophisticated as `emit`. Instead of some key and arbitrary serializable arguments, a stringified object is sent.
    * Objects contain a `type` and `payload`, following the same signatures as socket.io's emit key + payload. 
    * This is typed in `events.types.ts`
* Updates EventGateway to handle incoming websocket connections.
  * Internally, there's a mapping of message `type`s to handler functions.  
* Adds support for a few response/ack messages (`lobbyLeft`, `lobbyJoined`, etc) which are sent back to the calling socket. (These are not required, but helped a bit in my client-side testing.)
* Adds a new static room manager object, `ROOMMAN`, to handle joining + leaving rooms
  * Maybe it makes sense for this to also be a nest.js service

There's an [accompanying react repo](https://github.com/adketuri/itg-ws) to visualize received messages.
<img width="927" alt="image" src="https://github.com/user-attachments/assets/a26076fa-08ef-4be7-9853-ced379a424ab">
