### PR TITLE
Fix screenName ScreenEvaluationStage

### DIFF
--- a/src/types/models.types.ts
+++ b/src/types/models.types.ts
@@ -55,7 +55,7 @@ export interface Player {
     | 'ScreenSelectMusic'
     | 'ScreenGameplay'
     | 'ScreenPlayerOptions'
-    | 'ScreenEvaluation';
+    | 'ScreenEvaluationStage';
   ready: boolean;
 
   judgments?: Judgments;


### PR DESCRIPTION
Screen names are emitted from Simply Love and do not match what the server is expecting to read.
<img width="1531" height="601" alt="image" src="https://github.com/user-attachments/assets/a626ed2d-e3f5-4774-a46b-8b7b28a798ec" />
<img width="1536" height="611" alt="image" src="https://github.com/user-attachments/assets/3de0416a-a2d8-4e6e-9b4f-f64bb699ffc7" />
<img width="1531" height="799" alt="image" src="https://github.com/user-attachments/assets/63cfd620-8185-477d-8b4f-a72d09f39e56" />
<img width="1533" height="798" alt="image" src="https://github.com/user-attachments/assets/91e4fc9e-09ba-4e05-8d51-d2b8232ba798" />
